### PR TITLE
Added servo motor capabilities to Arduino boards using Snek language

### DIFF
--- a/ui/core/block_definitions.js
+++ b/ui/core/block_definitions.js
@@ -11466,6 +11466,39 @@ Blockly.Blocks['snek_setpower'] = {
  }
 };
 
+//Thu Mar 10 13:57:50 -03 2022
+
+Blockly.Blocks['snek_servo_move'] = {
+  init: function() {
+
+    this.appendDummyInput()
+        .appendField(new Blockly.FieldImage(
+          "media/servo.png",
+          55,
+          55,
+          "*"))
+        .appendField("Snek: RC Servo Motor");
+
+    this.appendValueInput("pin")
+        .setCheck("Number")
+        .setAlign(Blockly.ALIGN_RIGHT)
+        .appendField("Pin");
+
+    this.appendValueInput("angle")
+        .setCheck("Number")
+        .setAlign(Blockly.ALIGN_RIGHT)
+        .appendField("Angle");
+
+    this.setColour(230);
+
+    this.setPreviousStatement(true, null);
+    this.setNextStatement(true, null);
+
+    this.setTooltip("Move RC servo motor to degrees");
+    this.setHelpUrl("http://www.bipes.net.br");
+  }
+};
+
 Blockly.Blocks['google_spreadsheet'] = {
   init: function() {
     this.appendDummyInput()

--- a/ui/core/generator_stubs.js
+++ b/ui/core/generator_stubs.js
@@ -6073,6 +6073,23 @@ Blockly.Python['snek_gpio_get'] = function(block) {
   return [code, Blockly.Python.ORDER_NONE];
 };
 
+Blockly.Python['snek_servo_move'] = function(block) {
+	var pin = Blockly.Python.valueToCode(block, 'pin', Blockly.Python.ORDER_ATOMIC);
+	var value_pin = pin.replace('(', '').replace(')','');
+	var value_angle = Blockly.Python.valueToCode(block, 'angle', Blockly.Python.ORDER_ATOMIC);
+
+	var t_wait = "(" + value_angle + "/180)*0.002 + 0.0005";
+  
+	var code = 'talkto(' + value_pin + ')\n';
+	code += 'off()\n';
+	code += 'setpower(1)\n';
+	code += 'for turning in range(30) :\n';  // Give time to the servo reach it's angle
+	code += '  on()\n';
+	code += '  time.sleep(' + t_wait + ')\n';
+	code += '  off()\n';
+	code += '\n';
+	return code;
+};
 
 Blockly.Python['google_spreadsheet'] = function(block) {
   Blockly.Python.definitions_['import_prequests'] = 'import prequests';

--- a/ui/toolbox/arduino.xml
+++ b/ui/toolbox/arduino.xml
@@ -383,5 +383,21 @@
         </shadow>
       </value>
     </block>
-</category>
+  </category>
+
+  <category name="RC Servo Motor">
+      <label text="Snek RC Servo Motor"></label>
+    <block type="snek_servo_move">
+      <value name="pin">
+          <shadow type="pinout">
+            <field name="PIN"></field>
+          </shadow>
+        </value>
+      <value name="angle">
+        <shadow type="math_number">
+          <field name="NUM">90</field>
+        </shadow>
+      </value>
+    </block>
+  </category>
 </document>


### PR DESCRIPTION
Created RC Servo Motor category for Arduino boards. There, you can find a "Snek: RC Servo Motor" block.
It works by giving it a Arduino pin and an angle number input, and the output will be a Snek language code to make a servo motor to the position designated by the given angle value.

Other changes were added to the ui/core/utils.js file in order to allow BIPES to write the Snek code to the Arduino board's EEPROM memory. This will make the code run at startup.