### PR TITLE
decouple the servo name from the I/O pin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 ui/index_offline.html
+bipes_offline.zip

--- a/ui/core/block_definitions.js
+++ b/ui/core/block_definitions.js
@@ -1432,8 +1432,11 @@ Blockly.Blocks['move_servo'] = {
     this.setPreviousStatement(true, null);
     this.setNextStatement(true, null);
 
- this.setTooltip("Move RC servo motor to +/- 90 degrees");
- this.setHelpUrl("http://www.bipes.net.ebr");
+  this.setTooltip("Move RC servo motor to +/- 90 degrees");
+  this.setHelpUrl("http://www.bipes.net.ebr");
+  },
+  setID: function(id_) {
+    this.setFieldValue(id_, "SERVO_ID")
   }
 };
 

--- a/ui/core/generator_stubs.js
+++ b/ui/core/generator_stubs.js
@@ -558,6 +558,7 @@ Blockly.Python['tank_turn'] = function(block) {
 };
 
 Blockly.Python['init_servo'] = function(block) {
+	var number_id = block.getFieldValue('SERVO_ID');
 	var pin = Blockly.Python.valueToCode(block, 'pin', Blockly.Python.ORDER_NONE);
 
 	Blockly.Python.definitions_['import_pwm'] = 'from machine import PWM';
@@ -574,11 +575,11 @@ Blockly.Python['init_servo'] = function(block) {
 	+ ` tics = pulse_target * timer_resolution // 20000\n`
 	+ ` servo.duty_u16(tics)\n`
 
-	this.setID(pin)
+	this.setID(number_id)
 
-	var code = `pservo${pin} = Pin(${pin})\n`;
-	code += `servo${pin} = PWM(pservo${pin})\n`;
-	code += `servo${pin}.freq(50)\n`;
+	var code = `pservo${number_id} = Pin(${pin})\n`;
+	code += `servo${number_id} = PWM(pservo${number_id})\n`;
+	code += `servo${number_id}.freq(50)\n`;
 	return code;
 };
 
@@ -587,6 +588,8 @@ Blockly.Python['move_servo'] = function(block) {
 	var number_id = block.getFieldValue('SERVO_ID');
 	var value_angle = Blockly.Python.valueToCode(block, 'angle', Blockly.Python.ORDER_ATOMIC);
  
+	this.setID(number_id)
+
 	var code = `setServoAngle(servo${number_id},` + value_angle + `)\n`;
 	return code;
 };


### PR DESCRIPTION
The `offline` branch uses the pin number as the servo name in `servo_init()`. This forces the two fields to have similar values.
It then uses the ID as the identifier in `servo_angle()`.

This change uses the identifier in both places.  This lets us also store the servo pin in a variable before binding it to a pin

![2023-01-16_15-55-19](https://user-images.githubusercontent.com/1217160/212764376-ab01066c-10e7-4843-87db-5ed1649c0f0e.png)
