### PR TITLE
Removed faulty line in ESP8266 toolbox

### DIFF
--- a/ui/toolbox/esp8266.xml
+++ b/ui/toolbox/esp8266.xml
@@ -2012,8 +2012,7 @@ _
           </shadow>
         </value>
       </block>
-      <block type="mqtt_publish_payload">
-<category name="%{BKY_CAT_ULTRASOUND}">        <value name="topic">
+      <block type="mqtt_publish_payload">    <value name="topic">
           <shadow type="text">
             <field name="TEXT"></field>
           </shadow>


### PR DESCRIPTION
Removed what seemed to be a faulty line (copy paste mistake ?) in the ESP8266 XML, causing it to not load when choosing that device on the list (and instead keeping the previous toolbox on screen).