### PR TITLE
Add 100ms delay to serialWrite()

### DIFF
--- a/ui/core/channel.js
+++ b/ui/core/channel.js
@@ -509,6 +509,11 @@ class webserial {
       const writer = this.port.writable.getWriter();
       writer.write(dataArrayBuffer).then (() => {writer.releaseLock(); this.buffer_.shift ()});
 	  }
+    const date_time_delay = Date.now();  // create a time delay variable
+    let current_date_time = null;  
+    do {
+      current_date_time = Date.now();
+    } while (current_date_time - date_time_delay < 100); // 100 millisecond delay between sending code chunk arrarys (repeated calls to serialWrite) to ensure accurate receipt of micropython code at the microcontroller.
 	}
 }
 


### PR DESCRIPTION
Some microcontrollers use a USB-to-serial IC to connect the microcontroller to USB serial communication. Many of these USB-to-serial IC's require a delay between repeated calls of serial data transfers.

Issue https://github.com/BIPES/BIPES/issues/229 shows buffered characters are being dropped, with ESP32, when running code from BIPES due to a lack delay between data transfers. 

This pull request adds a 100ms delay to serialWrite() to prevent dropped characters from the serial data buffer.